### PR TITLE
Replace keys.fedoraproject.org with keys.openpgp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Initialize the library by creating a new PublicKey object.
 
 ####Arguments
 
-* `keyservers` - Array of keyserver domains (default is `["https://keys.fedoraproject.org/", "https://keybase.io/"]`).
+* `keyservers` - Array of keyserver domains (default is `["https://keys.openpgp.org/", "https://keybase.io/"]`).
 
 ####Examples
 

--- a/index.html
+++ b/index.html
@@ -145,8 +145,7 @@
                 and <a href="https://keybase.io/" target="_blank">Keybase</a>.
                 Try it out below by searching for "diafygi" (that's me!).
                 If you need to submit a new public key, please use the normal
-                SKS <a href="https://keys.fedoraproject.org/" target="_blank">interface</a>.
-
+                SKS <a href="https://keys.openpgp.org/" target="_blank">interface</a>.
             </p>
             <form>
                 <input id="q" name="q" placeholder="Type search here..."><input id="go" type="submit" value="Search"/>

--- a/publickey.js
+++ b/publickey.js
@@ -15,7 +15,7 @@
         Arguments:
 
         * keyservers - Array of keyserver domains, default is:
-            ["https://keys.fedoraproject.org/", "https://keybase.io/"]
+            ["https://keys.openpgp.org/", "https://keybase.io/"]
 
         Examples:
 

--- a/publickey.js
+++ b/publickey.js
@@ -5,7 +5,7 @@
         Default keyservers (HTTPS and CORS enabled)
     */
     var DEFAULT_KEYSERVERS = [
-        "https://keys.fedoraproject.org/",
+        "https://keys.openpgp.org/",
         "https://keybase.io/",
     ];
 


### PR DESCRIPTION
- Server keys.fedoraproject.org has been shut down
- Server keys.openpgp.org is actually the only public server that
supports CORS, which is required to use this script in a browser.